### PR TITLE
Add missing `hardware/clocks.h` header for `set_sys_clock_khz`

### DIFF
--- a/src/Gamecube_N64.h
+++ b/src/Gamecube_N64.h
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 #include <Arduino.h>
 #include "joybus.h"
+#include <hardware/clocks.h>
 #include <hardware/pio.h>
 #include <hardware/timer.h>
 #include <pico/stdlib.h>


### PR DESCRIPTION
pico-sdk 2.0.0で、`set_sys_clock_khz`関数が`pico/stdlib.h`から`hardware/clocks.h`に移っています。

- https://github.com/raspberrypi/pico-sdk/blame/efe2103f9b28458a1615ff096054479743ade236/src/rp2_common/hardware_clocks/include/hardware/clocks.h#L458-L467

`hardware/clocks.h`自体は以前からあるので、引き続き旧SDKでBluewhaleを使用する場合でも追加したインクルードは特に問題にならないはずです。

## 最小構成

```
$ tree . -L 2
.
├── include
├── lib
│   └── Bluewhale
├── platformio.ini
├── src
│   └── main.cpp
└── test
```

#### platformio.ini

```.ini
[env:pico]
platform = https://github.com/maxgerhardt/platform-raspberrypi.git#f519f650cbc787f5f58660b6e1bcf71c5083ecb8
board = pico
framework = arduino
board_build.core = earlephilhower
```

#### main.cpp

```.cpp
#include <Arduino.h>

#include <Bluewhale.h>

void setup() {}

void loop() {}
```

## ビルドログ

```
lib\Bluewhale\src\Gamecube_N64.c: In function 'gc_n64_send':
lib\Bluewhale\src\Gamecube_N64.c:61:9: warning: implicit declaration of function 'set_sys_clock_khz' [-Wimplicit-function-declaration]       
   61 |         set_sys_clock_khz(130000, true);
      |         ^~~~~~~~~~~~~~~~~
```

<details>
<summary>全文</summary>

```
Processing pico (platform: https://github.com/maxgerhardt/platform-raspberrypi.git#f519f650cbc787f5f58660b6e1bcf71c5083ecb8; board: pico; framework: arduino)
---------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
CONFIGURATION: https://docs.platformio.org/page/boards/raspberrypi/pico.html
PLATFORM: Raspberry Pi RP2040 (1.14.0+sha.f519f65) > Raspberry Pi Pico
HARDWARE: RP2040 133MHz, 256KB RAM, 2MB Flash
DEBUG: Current (blackmagic) External (blackmagic, cmsis-dap, jlink, pico-debug, picoprobe, raspberrypi-swd)
PACKAGES:
 - framework-arduinopico @ 1.40001.0+sha.6a5f98c
 - tool-picotool-rp2040-earlephilhower @ 5.120300.240827 (12.3.0)
 - toolchain-rp2040-earlephilhower @ 5.120300.240125 (12.3.0)
Flash size: 2.00MB
Sketch size: 2.00MB
Filesystem size: 0.00MB
Maximium Sketch size: 2093056 EEPROM start: 0x101ff000 Filesystem start: 0x101ff000 Filesystem end: 0x101ff000
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 66 compatible libraries
Scanning dependencies...
Dependency Graph
|-- Bluewhale @ 1.0.0
Building in release mode
Compiling .pio\build\pico\FrameworkArduinoBootloader\boot2_w25q080_2_padded_checksum.S.o
Compiling .pio\build\pico\src\main.cpp.o
Generating linkerscript C:\Users\mukai\prototyping\test_jiangtun\.pio\build\pico/memmap_default.ld
Compiling .pio\build\pico\lib89f\Bluewhale\Gamecube.c.o
Compiling .pio\build\pico\lib89f\Bluewhale\Gamecube_N64.c.o
Compiling .pio\build\pico\lib89f\Bluewhale\joybus.c.o
Compiling .pio\build\pico\FrameworkArduino\BluetoothDebug.cpp.o
Compiling .pio\build\pico\FrameworkArduino\Bootsel.cpp.o
Compiling .pio\build\pico\FrameworkArduino\CoreMutex.cpp.o
Compiling .pio\build\pico\FrameworkArduino\FS.cpp.o
Compiling .pio\build\pico\FrameworkArduino\PIOProgram.cpp.o
Compiling .pio\build\pico\FrameworkArduino\RP2040Support.cpp.o
Compiling .pio\build\pico\FrameworkArduino\RP2040USB.cpp.o
Compiling .pio\build\pico\FrameworkArduino\SerialPIO.cpp.o
Compiling .pio\build\pico\FrameworkArduino\SerialUART.cpp.o
Compiling .pio\build\pico\FrameworkArduino\SerialUSB.cpp.o
lib\Bluewhale\src\Gamecube_N64.c: In function 'gc_n64_send':
lib\Bluewhale\src\Gamecube_N64.c:61:9: warning: implicit declaration of function 'set_sys_clock_khz' [-Wimplicit-function-declaration]       
   61 |         set_sys_clock_khz(130000, true);
      |         ^~~~~~~~~~~~~~~~~
Compiling .pio\build\pico\FrameworkArduino\StackThunk.cpp.o
Compiling .pio\build\pico\FrameworkArduino\Tone.cpp.o
Compiling .pio\build\pico\FrameworkArduino\WMath.cpp.o
Archiving .pio\build\pico\lib89f\libBluewhale.a
Indexing .pio\build\pico\lib89f\libBluewhale.a
Compiling .pio\build\pico\FrameworkArduino\_freertos.cpp.o
Compiling .pio\build\pico\FrameworkArduino\api\Common.cpp.o
Compiling .pio\build\pico\FrameworkArduino\api\IPAddress.cpp.o
Compiling .pio\build\pico\FrameworkArduino\api\PluggableUSB.cpp.o
Compiling .pio\build\pico\FrameworkArduino\api\Print.cpp.o
Compiling .pio\build\pico\FrameworkArduino\api\Stream.cpp.o
Compiling .pio\build\pico\FrameworkArduino\api\String.cpp.o
Compiling .pio\build\pico\FrameworkArduino\cyw43_wrappers.cpp.o
Compiling .pio\build\pico\FrameworkArduino\delay.cpp.o
Compiling .pio\build\pico\FrameworkArduino\libb64\cdecode.cpp.o
Compiling .pio\build\pico\FrameworkArduino\libb64\cencode.cpp.o
Compiling .pio\build\pico\FrameworkArduino\lock.cpp.o
Compiling .pio\build\pico\FrameworkArduino\lwip_wrap.cpp.o
Compiling .pio\build\pico\FrameworkArduino\main.cpp.o
Compiling .pio\build\pico\FrameworkArduino\malloc-lock.cpp.o
Compiling .pio\build\pico\FrameworkArduino\posix.cpp.o
Compiling .pio\build\pico\FrameworkArduino\psram.cpp.o
Compiling .pio\build\pico\FrameworkArduino\sdkoverride\att_db.c.o
Compiling .pio\build\pico\FrameworkArduino\sdkoverride\btstack_flash_bank.cpp.o
Compiling .pio\build\pico\FrameworkArduino\sdkoverride\hids_device.c.o
Compiling .pio\build\pico\FrameworkArduino\sdkoverride\inet_chksum.cpp.o
Compiling .pio\build\pico\FrameworkArduino\sdkoverride\newlib_interface.c.o
Compiling .pio\build\pico\FrameworkArduino\sdkoverride\pico_bootsel_via_double_reset.c.o
Compiling .pio\build\pico\FrameworkArduino\stdlib_noniso.cpp.o
Compiling .pio\build\pico\FrameworkArduino\wiring_analog.cpp.o
Compiling .pio\build\pico\FrameworkArduino\wiring_digital.cpp.o
Compiling .pio\build\pico\FrameworkArduino\wiring_private.cpp.o
Compiling .pio\build\pico\FrameworkArduino\wiring_pulse.cpp.o
Compiling .pio\build\pico\FrameworkArduino\wiring_shift.cpp.o
Archiving .pio\build\pico\libFrameworkArduino.a
Indexing .pio\build\pico\libFrameworkArduino.a
Linking .pio\build\pico\firmware.elf
Generating UF2 image
picotool uf2 convert -t elf ".pio\build\pico\firmware.elf" ".pio\build\pico\firmware.uf2"
Retrieving maximum program size .pio\build\pico\firmware.elf
Flash size: 2.00MB
Sketch size: 2.00MB
Filesystem size: 0.00MB
Maximium Sketch size: 2093056 EEPROM start: 0x101ff000 Filesystem start: 0x101ff000 Filesystem end: 0x101ff000
Checking size .pio\build\pico\firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [          ]   3.5% (used 9172 bytes from 262144 bytes)
Flash: [          ]   2.6% (used 55116 bytes from 2093056 bytes)
Building .pio\build\pico\firmware.bin
Building .pio\build\pico\firmware.bin.signed
======================================================== [SUCCESS] Took 7.40 seconds ========================================================
 *  ターミナルはタスクで再利用されます、閉じるには任意のキーを押してください。 
```
  
</details>